### PR TITLE
hack for submodules

### DIFF
--- a/git-remote-hg
+++ b/git-remote-hg
@@ -840,8 +840,14 @@ def parse_commit(parser):
     for line in parser:
         if parser.check('M'):
             t, m, mark_ref, path = line.split(' ', 3)
-            mark = int(mark_ref[1:])
-            f = { 'mode': hgmode(m), 'data': blob_marks[mark] }
+            if m == '160000':
+                # This is a submodule -- there is no reasonable
+                # way to import it.
+                blob_data = "[git-remote-hg: skipped import of submodule at %s]" % mark_ref
+            else:
+                mark = int(mark_ref[1:])
+                blob_data = blob_marks[mark]
+            f = { 'mode': hgmode(m), 'data': blob_data }
         elif parser.check('D'):
             t, path = line.split(' ', 1)
             f = { 'deleted': True }

--- a/test/main-push.t
+++ b/test/main-push.t
@@ -278,6 +278,36 @@ test_expect_success 'push with renamed executable preserves executable bit' '
 	)
 '
 
+test_expect_success 'push with submodule' '
+	test_when_finished "rm -rf sub hgrepo gitrepo*" &&
+
+	hg init hgrepo &&
+
+	(
+	git init sub &&
+	cd sub &&
+	: >empty &&
+	git add empty &&
+	git commit -m init
+	) &&
+
+	(
+	git init gitrepo &&
+	cd gitrepo &&
+	git submodule add ../sub sub &&
+	git remote add origin "hg::../hgrepo" &&
+	git commit -a -m sub &&
+	git push origin master
+	) &&
+
+	(
+	cd hgrepo &&
+	hg update &&
+	expected="[git-remote-hg: skipped import of submodule at $(git -C ../sub rev-parse HEAD)]"
+	test "$expected" = "$(cat sub)"
+	)
+'
+
 # cleanup setting
 git config --global --unset remote-hg.shared-marks
 


### PR DESCRIPTION
A complete solution for submodules might be to convert them to hg
subrepositories.  But this would, in the general case, be quite
difficult -- for instance, local copies of all historical submodule
commits might not be available, and repositories might have moved
around.

It's better to do the conversion in some understandable way than to
crash with a weird error message, so let's do that.