### PR TITLE
Optionally don't mangle git usernames with quotes

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -226,6 +226,20 @@ also be enabled on an existing one by the following setting.
 --------------------------------------
 Note, however, that one should then perform a fetch from each relevant remote
 to fully complete the conversion (prior to subsequent pushing).
+--------------------------------------
+% git config --global remote-hg.remove-username-quotes false
+
+By default, for backwards compatibility with earlier versions,
+git-remote-hg removes quotation marks from git usernames
+(e.g. 'Raffaello "Raphael" Sanzio da Urbino <raphael@example.com>'
+would become 'Raffaello Raphael Sanzio da Urbino
+<raphael@example.com>').  This breaks round-trip compatibility; a git
+commit by an author with quotes would become an hg commit without,
+and if re-imported into git, would get a different SHA1.
+
+To restore round-trip compatibility (at the cost of backwards
+compatibility with commits converted by older versions of
+git-remote-hg), turn 'remote-hg.remove-username-quotes' off.
 
 === Helper Commands ===
 

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -334,7 +334,9 @@ def get_filechanges(repo, ctx, parent):
 
 def fixup_user_git(user):
     name = mail = None
-    user = user.replace('"', '')
+    global remove_username_quotes
+    if remove_username_quotes:
+        user = user.replace('"', '')
     m = AUTHOR_RE.match(user)
     if m:
         name = m.group(1)
@@ -1646,6 +1648,7 @@ def main(args):
     global dry_run
     global notes, alias
     global capability_push
+    global remove_username_quotes
     global marksdir
 
     marks = None
@@ -1665,6 +1668,7 @@ def main(args):
     hg_git_compat = get_config_bool('remote-hg.hg-git-compat')
     track_branches = get_config_bool('remote-hg.track-branches', True)
     capability_push = get_config_bool('remote-hg.capability-push', True)
+    remove_username_quotes = get_config_bool('remote-hg.remove-username-quotes', True)
     force_push = False
 
     if hg_git_compat:


### PR DESCRIPTION
By default, for backwards compatibility with earlier versions,
git-remote-hg removes quotation marks from git usernames
(e.g. 'Raffaello "Raphael" Sanzio da Urbino \<raphael@example.com\>'
would become 'Raffaello Raphael Sanzio da Urbino
\<raphael@example.com\>').  This breaks round-trip compatibility; a git
commit by an author with quotes would become an hg commit without,
and if re-imported into git, would get a different SHA1.

To restore round-trip compatibility (at the cost of backwards
compatibility with commits converted by older versions of
git-remote-hg), add an option 'remote-hg.remove-username-quotes'. This
option defaults to true (for backwards compatibility).