### PR TITLE
Fix obscure bug with multiple independent histories

### DIFF
--- a/git-remote-hg
+++ b/git-remote-hg
@@ -581,7 +581,7 @@ def export_ref(repo, name, kind, head):
             if extra_msg:
                 desc += '\n--HG--\n' + extra_msg
 
-        if len(parents) == 0 and rev:
+        if len(parents) == 0:
             print 'reset %s/%s' % (prefix, ename)
 
         modified_final = export_files(c.filectx(f) for f in modified)


### PR DESCRIPTION
If you have a repository with multiple independent histories (perhaps
that get merged later), under some circumstances revision 0 can get
imported *after* some other revision.  "Independent histories" are those
that start from different zero-parent commits.  I have thus far failed to
get a local reproduction on this, in part because I don't understand
how git-remote-hg choses the order in which to import branches.  But
we did notice this in our production system.

If revision 0 is imported late, a reset would not be issued, and it would
be wrongly re-parented on top of whatever previous history existed, instead
of being a root-level commit.

Fix this by always issuing a reset for a parentless commit, even on
revision 0.