### PR TITLE
Use ui.ui.load() to create a new ui which loads the global and user hg config

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -108,6 +108,23 @@ However, some of these features require very new versions of 'git-remote-hg',
 so you might have better luck simply specifying the username and password in
 the URL.
 
+=== Submodules ===
+
+Hg repositories can be used as git submodule, but this requires to allow the hg procotol to be used by git submodule commands:
+
+--------------------------------------
+git config protocol.hg.allow always
+--------------------------------------
+
+Or adding manually the following to your git configuration file:
+
+--------------------------------------
+[protocol "hg"]
+        allow = always
+--------------------------------------
+
+This can be done per-repository, every time after a clone, or globally in the global .gitconfig (using the --global command-line option).
+
 === Caveats ===
 
 The only major incompatibility is that Git octopus merges (a merge with more

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -427,7 +427,7 @@ def updatebookmarks(repo, peer):
 def get_repo(url, alias):
     global peer
 
-    myui = ui.ui()
+    myui = ui.ui.load()
     myui.setconfig('ui', 'interactive', 'off')
     myui.fout = sys.stderr
 


### PR DESCRIPTION
I have mercurial configuration located in my home, and there was a regression with newer mercurial or newer git-remote-hg versions where my configuration is ignored.

For example, I usually mark my mercurial commits as secret by default with a global setting, so I have time to refactor my commits in a git way before really pushing them to the mercurial remote (changing the phase by hand, and cherry-piking the commit to push in tortoise-hg).