### PR TITLE
A bit of python3 compatibility

### DIFF
--- a/git-hg-helper
+++ b/git-hg-helper
@@ -3,6 +3,7 @@
 # Copyright (c) 2016 Mark Nauwelaerts
 #
 
+from __future__ import print_function
 from mercurial import hg, ui, commands, util
 from mercurial import context, subrepo
 
@@ -322,7 +323,7 @@ class HgRevCommand(SubCommand):
         if len(args):
             hgrev = self.githgrepo.get_hg_rev(args[0])
             if hgrev:
-                print hgrev
+                print(hgrev)
 
 
 class GitMarks:
@@ -375,7 +376,7 @@ class GitRevCommand(SubCommand):
             rev = args[0]
             gitcommit = self.githgrepo.get_git_commit(rev)
             if gitcommit:
-                print gitcommit
+                print(gitcommit)
 
 
 class GcCommand(SubCommand):
@@ -422,15 +423,15 @@ class GcCommand(SubCommand):
             if not remote in hg_repos:
                 self.usage('%s is not a valid hg remote' % (remote))
             hgpath = remotehg.select_marks_dir(remote, self.githgrepo.gitdir, False)
-            print "Loading hg marks ..."
+            print("Loading hg marks ...")
             hgm = remotehg.Marks(os.path.join(hgpath, 'marks-hg'), None)
-            print "Loading git marks ..."
+            print("Loading git marks ...")
             gm = GitMarks(os.path.join(hgpath, 'marks-git'))
             repo = hg.repository(ui.ui(), hg_repos[remote]) if options.check_hg else None
             # git-gc may have dropped unreachable commits
             # (in particular due to multiple hg head cases)
             # need to drop those so git-fast-export or git-fast-import does not complain
-            print "Performing garbage collection on git commits ..."
+            print("Performing garbage collection on git commits ...")
             process = self.githgrepo.start_cmd(['cat-file', '--batch-check'], \
                 stdin=subprocess.PIPE)
             thread = threading.Thread(target=self.print_commits, args=(gm, process.stdin))
@@ -442,7 +443,7 @@ class GcCommand(SubCommand):
                     git_marks.add(gm.from_rev(sp[0]))
             thread.join()
             # reduce down to marks that are common to both
-            print "Computing marks intersection ..."
+            print("Computing marks intersection ...")
             common_marks = set(hgm.rev_marks.keys()).intersection(git_marks)
             hg_rev_marks = {}
             git_rev_marks = {}
@@ -453,7 +454,7 @@ class GcCommand(SubCommand):
                 git_rev_marks[m] = gm.rev_marks[m]
             # common marks will not not include any refs/notes/hg
             # let's not discard those casually, though they are not vital
-            print "Including notes commits ..."
+            print("Including notes commits ...")
             revlist = self.githgrepo.start_cmd(['rev-list', 'refs/notes/hg'])
             for l in revlist.stdout.readlines():
                 c = l.strip()
@@ -465,21 +466,21 @@ class GcCommand(SubCommand):
                 git_rev_marks[hgm.last_note] = gm.rev_marks[hgm.last_note]
             # some status report
             if len(hgm.rev_marks) != len(hg_rev_marks):
-                print "Trimmed hg marks from #%d down to #%d" % (len(hgm.rev_marks), len(hg_rev_marks))
+                print("Trimmed hg marks from #%d down to #%d" % (len(hgm.rev_marks), len(hg_rev_marks)))
             if len(gm.rev_marks) != len(git_rev_marks):
-                print "Trimmed git marks from #%d down to #%d" % (len(gm.rev_marks), len(git_rev_marks))
+                print("Trimmed git marks from #%d down to #%d" % (len(gm.rev_marks), len(git_rev_marks)))
             # marks-hg tips irrelevant nowadays
             # now update and store
             if not options.dry_run:
                 # hg marks
-                print "Writing hg marks ..."
+                print("Writing hg marks ...")
                 hgm.rev_marks = hg_rev_marks
                 hgm.marks = {}
                 for mark, rev in hg_rev_marks.iteritems():
                     hgm.marks[rev] = mark
                 hgm.store()
                 # git marks
-                print "Writing git marks ..."
+                print("Writing git marks ...")
                 gm.rev_marks = git_rev_marks
                 gm.marks = {}
                 for mark, rev in git_rev_marks.iteritems():
@@ -698,7 +699,7 @@ class SubRepoCommand(SubCommand):
             die('no .hgsubstate found in repo %s' % ctx.repo.topdir)
         if orig != rev:
             short = ctx.subrepo.rev_parse(['--short', gitcommit])
-            print "Updating %s to %s [git %s]" % (ctx.subpath, rev, short)
+            print("Updating %s to %s [git %s]" % (ctx.subpath, rev, short))
             # replace and update index
             with open(state_path, 'r') as f:
                 state = f.read()
@@ -710,7 +711,7 @@ class SubRepoCommand(SubCommand):
         if not ctx.subrepo:
             return
         if not options.quiet:
-            print 'Entering %s' % ctx.subpath
+            print('Entering %s' % ctx.subpath)
             sys.stdout.flush()
         newenv = os.environ.copy()
         newenv['path'] = ctx.relpath
@@ -775,7 +776,7 @@ class SubRepoCommand(SubCommand):
             revname = ctx.subrepo.rev_describe(gitcommit)
             if revname:
                 revname = ' (%s)' % revname
-        print "%s%s %s%s" % (state, gitcommit, ctx.subpath, revname)
+        print("%s%s %s%s" % (state, gitcommit, ctx.subpath, revname))
 
     def cmd_sync(self, options, args, ctx):
         if not ctx.subrepo:
@@ -801,7 +802,7 @@ class RepoCommand(SubCommand):
         (remote, args) = self.get_remote(args)
         repos = self.githgrepo.get_hg_repos()
         if remote in repos:
-            print repos[remote].rstrip('/')
+            print(repos[remote].rstrip('/'))
 
 
 class HgCommand(SubCommand):
@@ -897,7 +898,7 @@ def init_git(gitdir=None):
 
     try:
         githgrepo = GitHgRepo(gitdir=gitdir)
-    except Exception, e:
+    except Exception as e:
         die(str(e))
 
 def init_logger():

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -13,6 +13,7 @@
 # For remote repositories a local clone is stored in
 # "$GIT_DIR/hg/origin/clone/.hg/".
 
+from __future__ import print_function
 from mercurial import hg, ui, bookmarks, context, encoding
 from mercurial import node, error, extensions, discovery, util
 from mercurial import changegroup
@@ -302,10 +303,10 @@ def export_files(files):
             filenodes[fid] = mark
             d = f.data()
 
-            print "blob"
-            print "mark :%u" % mark
-            print "data %d" % len(d)
-            print d
+            print("blob")
+            print("mark :%u" % mark)
+            print("data %d" % len(d))
+            print(d)
 
         path = fix_file_path(f.path())
         final.append((gitmode(f.flags()), mark, path))
@@ -526,7 +527,7 @@ def revwalk(repo, name, b):
                     pending.add(p)
 
         if cur % interval == 0:
-            print "progress revision walk '%s' (%d/%d)" % (name, (b.rev() - cur), b.rev())
+            print("progress revision walk '%s' (%d/%d)" % (name, (b.rev() - cur), b.rev()))
 
     positive.reverse()
     return positive
@@ -592,35 +593,35 @@ def export_ref(repo, name, kind, head):
                 desc += '\n--HG--\n' + extra_msg
 
         if len(parents) == 0:
-            print 'reset %s/%s' % (prefix, ename)
+            print('reset %s/%s' % (prefix, ename))
 
         modified_final = export_files(c.filectx(f) for f in modified)
 
-        print "commit %s/%s" % (prefix, ename)
-        print "mark :%d" % (marks.get_mark(c.hex()))
-        print "author %s" % (author)
-        print "committer %s" % (committer)
-        print "data %d" % (len(desc))
-        print desc
+        print("commit %s/%s" % (prefix, ename))
+        print("mark :%d" % (marks.get_mark(c.hex())))
+        print("author %s" % (author))
+        print("committer %s" % (committer))
+        print("data %d" % (len(desc)))
+        print(desc)
 
         if len(parents) > 0:
-            print "from :%s" % (rev_to_mark(parents[0]))
+            print("from :%s" % (rev_to_mark(parents[0])))
             if len(parents) > 1:
-                print "merge :%s" % (rev_to_mark(parents[1]))
+                print("merge :%s" % (rev_to_mark(parents[1])))
 
         for f in removed:
-            print "D %s" % (fix_file_path(f))
+            print("D %s" % (fix_file_path(f)))
         for f in modified_final:
-            print "M %s :%u %s" % f
-        print
+            print("M %s :%u %s" % f)
+        print()
 
         if (progress % 100 == 0):
-            print "progress revision %d '%s' (%d/%d)" % (rev, name, progress, total)
+            print("progress revision %d '%s' (%d/%d)" % (rev, name, progress, total))
 
     # make sure the ref is updated
-    print "reset %s/%s" % (prefix, ename)
-    print "from :%u" % rev_to_mark(head)
-    print
+    print("reset %s/%s" % (prefix, ename))
+    print("from :%u" % rev_to_mark(head))
+    print()
 
     pending_revs = set(revs) - notes
     if pending_revs:
@@ -644,28 +645,28 @@ def export_head(repo):
     export_ref(repo, g_head[0], 'bookmarks', g_head[1])
 
 def do_capabilities(parser):
-    print "import"
+    print("import")
     if capability_push:
-        print "push"
+        print("push")
     else:
-        print "export"
-    print "refspec refs/heads/branches/*:%s/branches/*" % prefix
-    print "refspec refs/heads/*:%s/bookmarks/*" % prefix
-    print "refspec refs/tags/*:%s/tags/*" % prefix
+        print("export")
+    print("refspec refs/heads/branches/*:%s/branches/*" % prefix)
+    print("refspec refs/heads/*:%s/bookmarks/*" % prefix)
+    print("refspec refs/tags/*:%s/tags/*" % prefix)
 
     path = os.path.join(marksdir, 'marks-git')
 
     if os.path.exists(path):
-        print "*import-marks %s" % path
-    print "*export-marks %s" % path
-    print "option"
+        print("*import-marks %s" % path)
+    print("*export-marks %s" % path)
+    print("option")
     # nothing really depends on the private refs being up to date
     # (export is limited anyway by the current git marks)
     # and they are not always updated correctly (dry-run, bookmark delete, ...)
     # (might resolve some dry-run breakage also)
-    print "no-private-update"
+    print("no-private-update")
 
-    print
+    print()
 
 def branch_tip(branch):
     return branches[branch][-1]
@@ -695,7 +696,7 @@ def list_head(repo, cur):
     bmarks[head] = node
 
     head = gitref(head)
-    print "@refs/heads/%s HEAD" % head
+    print("@refs/heads/%s HEAD" % head)
     g_head = (head, node)
 
 def do_list(parser):
@@ -741,32 +742,32 @@ def do_list(parser):
     if track_branches:
         for branch in branches:
             if not ignore('branch', branch):
-                print "%s refs/heads/branches/%s" % (sha1, gitref(branch))
+                print("%s refs/heads/branches/%s" % (sha1, gitref(branch)))
 
     for bmark in bmarks:
         if bmarks[bmark].hex() == '0' * 40:
             warn("Ignoring invalid bookmark '%s'", bmark)
         elif not ignore('bookmark', bmark):
-            print "%s refs/heads/%s" % (sha1, gitref(bmark))
+            print("%s refs/heads/%s" % (sha1, gitref(bmark)))
 
     for tag, node in repo.tagslist():
         if tag == 'tip':
             continue
         if not ignore('tag', tag):
-            print "%s refs/tags/%s" % (sha1, gitref(tag))
+            print("%s refs/tags/%s" % (sha1, gitref(tag)))
 
-    print
+    print()
 
 def do_import(parser):
     repo = parser.repo
 
     path = os.path.join(marksdir, 'marks-git')
 
-    print "feature done"
+    print("feature done")
     if os.path.exists(path):
-        print "feature import-marks=%s" % path
-    print "feature export-marks=%s" % path
-    print "feature force"
+        print("feature import-marks=%s" % path)
+    print("feature export-marks=%s" % path)
+    print("feature force")
     sys.stdout.flush()
 
     tmp = encoding.encoding
@@ -788,19 +789,19 @@ def do_import(parser):
             tag = ref[len('refs/tags/'):]
             export_tag(repo, tag)
 
-        parser.next()
+        next(parser)
 
     encoding.encoding = tmp
 
-    print 'done'
+    print('done')
 
 def parse_blob(parser):
-    parser.next()
+    next(parser)
     mark = parser.get_mark()
-    parser.next()
+    next(parser)
     data = parser.get_data()
     blob_marks[mark] = data
-    parser.next()
+    next(parser)
 
 def get_file_metadata(repo, p1, files):
     for e in files:
@@ -851,22 +852,22 @@ def parse_commit(parser):
 
     remoteref = parser.context.remoteref
     ref = parser[1] if not remoteref else remoteref
-    parser.next()
+    next(parser)
 
     commit_mark = parser.get_mark()
-    parser.next()
+    next(parser)
     author = parser.get_author()
-    parser.next()
+    next(parser)
     committer = parser.get_author()
-    parser.next()
+    next(parser)
     data = parser.get_data()
-    parser.next()
+    next(parser)
     if parser.check('from'):
         from_mark = parser.get_mark()
-        parser.next()
+        next(parser)
     if parser.check('merge'):
         merge_mark = parser.get_mark()
-        parser.next()
+        next(parser)
         if parser.check('merge'):
             die('octopus merges are not supported yet')
 
@@ -918,7 +919,7 @@ def parse_commit(parser):
         if hgrev:
             hghelper = parser.context.hghelper
             if not hghelper:
-                print "error %s rejected not pushing hg based commit %s" % (ref, gitcommit)
+                print("error %s rejected not pushing hg based commit %s" % (ref, gitcommit))
                 raise UserWarning("check-hg-commits")
             # must be in some local repo
             # find it and push it to the target local repo
@@ -1037,7 +1038,7 @@ def parse_commit(parser):
 def parse_reset(parser):
     remoteref = parser.context.remoteref
     ref = parser[1] if not remoteref else remoteref
-    parser.next()
+    next(parser)
     # ugh
     if parser.check('commit'):
         parse_commit(parser)
@@ -1045,7 +1046,7 @@ def parse_reset(parser):
     if not parser.check('from'):
         return
     from_mark = parser.get_mark()
-    parser.next()
+    next(parser)
 
     try:
         rev = mark_to_rev(from_mark)
@@ -1055,13 +1056,13 @@ def parse_reset(parser):
 
 def parse_tag(parser):
     name = parser[1]
-    parser.next()
+    next(parser)
     from_mark = parser.get_mark()
-    parser.next()
+    next(parser)
     tagger = parser.get_author()
-    parser.next()
+    next(parser)
     data = parser.get_data()
-    parser.next()
+    next(parser)
 
     parsed_tags[name] = (tagger, data)
 
@@ -1118,14 +1119,14 @@ def checkheads_bmark(repo, ref, ctx, force):
     ctx_new = ctx
 
     if not ctx.rev():
-        print "error %s unknown" % ref
+        print("error %s unknown" % ref)
         return False
 
     if not repo.changelog.descendant(ctx_old.rev(), ctx_new.rev()):
         if force:
-            print "ok %s forced update" % ref
+            print("ok %s forced update" % ref)
         else:
-            print "error %s non-fast forward" % ref
+            print("error %s non-fast forward" % ref)
             return False
 
     return True
@@ -1175,9 +1176,9 @@ def checkheads(repo, remote, p_revs, force):
             node = repo.changelog.node(rev)
             ref = p_revs[node]
             if force:
-                print "ok %s forced update" % ref
+                print("ok %s forced update" % ref)
             else:
-                print "error %s non-fast forward" % ref
+                print("error %s non-fast forward" % ref)
                 ret = False
 
     return ret
@@ -1226,7 +1227,7 @@ def push_unsafe(repo, remote, p_revs, force):
 
 def push(repo, remote, p_revs, force):
     if hasattr(remote, 'canpush') and not remote.canpush():
-        print "error cannot push"
+        print("error cannot push")
 
     if not p_revs:
         # nothing to push
@@ -1246,7 +1247,7 @@ def push(repo, remote, p_revs, force):
 
 def do_export(parser):
     do_push_hg(parser)
-    print
+    print()
 
 def do_push_hg(parser):
     global parsed_refs, parsed_tags
@@ -1256,7 +1257,7 @@ def do_push_hg(parser):
     parsed_refs = {}
     parsed_tags = {}
 
-    parser.next()
+    next(parser)
 
     remoteref = parser.context.remoteref
     if remoteref and not parser.line:
@@ -1268,7 +1269,7 @@ def do_push_hg(parser):
         if not hgrev:
             # maybe the notes are not updated
             # happens only on fetch for now ... let's ask for that
-            print "error %s fetch first" % remoteref
+            print("error %s fetch first" % remoteref)
             return False
         parsed_refs[remoteref] = hgrev
         # now make parser happy
@@ -1294,21 +1295,21 @@ def do_push_hg(parser):
             branch = ref[len('refs/heads/branches/'):]
             if branch in branches and bnode in branches[branch]:
                 # up to date
-                print "ok %s up to date" % ref
+                print("ok %s up to date" % ref)
                 continue
 
             p_revs[bnode] = ref
-            print "ok %s" % ref
+            print("ok %s" % ref)
         elif ref.startswith('refs/heads/'):
             bmark = ref[len('refs/heads/'):]
             new = node
             old = bmarks[bmark].hex() if bmark in bmarks else ''
 
             if old == new:
-                print "ok %s up to date" % ref
+                print("ok %s up to date" % ref)
                 continue
 
-            print "ok %s" % ref
+            print("ok %s" % ref)
             if bmark != fake_bmark and \
                     not (bmark == 'master' and bmark not in parser.repo._bookmarks):
                 p_bmarks.append((ref, bmark, old, new))
@@ -1316,7 +1317,7 @@ def do_push_hg(parser):
             p_revs[bnode] = ref
         elif ref.startswith('refs/tags/'):
             if dry_run:
-                print "ok %s" % ref
+                print("ok %s" % ref)
                 continue
             tag = ref[len('refs/tags/'):]
             tag = hgref(tag)
@@ -1337,7 +1338,7 @@ def do_push_hg(parser):
                 fp.write('%s %s\n' % (node, tag))
                 fp.close()
             p_revs[bnode] = ref
-            print "ok %s" % ref
+            print("ok %s" % ref)
         else:
             # transport-helper/fast-export bugs
             continue
@@ -1364,13 +1365,13 @@ def do_push_hg(parser):
                 old = remote_bmarks.get(bmark, '')
             if not peer.pushkey('bookmarks', bmark, old, new):
                 success = False
-                print "error %s" % ref
+                print("error %s" % ref)
     else:
         # update local bookmarks
         for ref, bmark, old, new in p_bmarks:
             if not bookmarks.pushbookmark(parser.repo, bmark, old, new):
                 success = False
-                print "error %s" % ref
+                print("error %s" % ref)
 
     return success
 
@@ -1405,20 +1406,20 @@ def do_push_refspec(parser, refspec, revs):
     if (not refs[0]) and refs[1].startswith('refs/heads') and \
             not refs[1].startswith('refs/heads/branches'):
         if not dry_run and not delete_bookmark(parser, refs[1]):
-            print "error %s could not delete"% (refs[1])
+            print("error %s could not delete"% (refs[1]))
         else:
-            print "ok %s" % (refs[1])
+            print("ok %s" % (refs[1]))
         return
     # sanity check on remote ref
     if not (refs[1].startswith('refs/heads') or refs[1].startswith('refs/tags')):
-        print "error %s refspec not supported " % refs[1]
+        print("error %s refspec not supported " % refs[1])
         return
     ctx = ParserContext()
     if refs[0] != refs[1]:
         # would work and tag as requested, but pushing to a hg permanent branch
         # based on a rename rather than a git branch is probably not a good idea
         if refs[1].startswith('refs/heads/branches'):
-            print "error %s not allowed for permanent branch" % refs[1]
+            print("error %s not allowed for permanent branch" % refs[1])
             return
         ctx.remoteref = refs[1]
         ctx.localref = refs[0]
@@ -1552,7 +1553,7 @@ def do_push(parser):
             revs.extend(localrevs)
         else:
             die('unhandled push command: %s' % (line))
-    print
+    print()
     # at this stage, all external processes are done, marks files written
     # so we can use those to update notes
     # do so unconditionally because we can and should ....
@@ -1563,12 +1564,12 @@ def do_option(parser):
     _, key, value = parser.line.split(' ')
     if key == 'dry-run':
         dry_run = (value == 'true')
-        print 'ok'
+        print('ok')
     elif key == 'force':
         force_push = (value == 'true')
-        print 'ok'
+        print('ok')
     else:
-        print 'unsupported'
+        print('unsupported')
 
 def fix_path(alias, repo, orig_url):
     url = urlparse.urlparse(orig_url, 'file')


### PR DESCRIPTION
Mainly it sets parenthesis to the print function, but it also prefers `next(foobar)` to `foobar.next()`.

This was automatically generated by the command `futurize -1 -w -n git-hg-helper git-remote-hg` from the [python-future](http://python-future.org/) project.