### PR TITLE
Use a compatible umask for the executable bit preservation test

### DIFF
--- a/test/main-push.t
+++ b/test/main-push.t
@@ -270,10 +270,10 @@ test_expect_success 'push with renamed executable preserves executable bit' '
 	) &&
 
 	(
+	umask 0 &&
 	cd hgrepo &&
 	hg update &&
 	stat content2 >expected &&
-	# umask mileage might vary
 	grep -- -r.xr.xr.x expected
 	)
 '


### PR DESCRIPTION
More restrictive umasks like 027 will cause the test to fail.

Ubuntu 21.04 will change the default umask to 027.