### PR TITLE
Expect success for the main pull tags test

### DIFF
--- a/test/main.t
+++ b/test/main.t
@@ -1093,7 +1093,7 @@ test_expect_success 'push bookmark without changesets' '
 	check_bookmark hgrepo feature-a two
 '
 
-test_expect_unstable 'pull tags' '
+test_expect_success 'pull tags' '
 	test_when_finished "rm -rf hgrepo gitrepo" &&
 
 	(


### PR DESCRIPTION
The git bug that caused the switch to unstable has been fixed.

This reverts commit a5dfc9025bd6c49537be4b3cec548cac261eaf97.