### PR TITLE
Add an option to test the pre-installed scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ build:
 		PYTHON=python2 ; \
 	elif python -c 'import mercurial' 2> /dev/null ; then \
 		PYTHON=python ; \
+	else ; \
+		echo 'Python with Mercurial not available' >&2 ; \
+		exit 1 ; \
 	fi ; \
 	mkdir -p bin ; \
 	for s in git-remote-hg git-hg-helper ; do \

--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,6 @@ build:
 	elif python -c 'import mercurial' 2> /dev/null ; then \
 		PYTHON=python ; \
 	fi ; \
-	if [ -n "$$PYTHON" ] ; then \
-		PYTHON=python ; \
-	fi ; \
 	mkdir -p bin ; \
 	for s in git-remote-hg git-hg-helper ; do \
 		printf "%s\n" "#!/usr/bin/env $$PYTHON" > "bin/$$s" ; \

--- a/test/test-lib.sh
+++ b/test/test-lib.sh
@@ -27,28 +27,33 @@ SHARNESS_BUILD_DIRECTORY="$(mktemp -d)"
 export PATH="${PATH#*:}"
 rmdir "$SHARNESS_BUILD_DIRECTORY"
 
-if [ -n "$PYTHON" ] && "$PYTHON" -c 'import mercurial' 2> /dev/null ; then
-	: Use chosen Python version
-elif python3 -c 'import mercurial' 2> /dev/null ; then
-	PYTHON=python3
-elif python2 -c 'import mercurial' 2> /dev/null ; then
-	PYTHON=python2
-elif python -c 'import mercurial' 2> /dev/null ; then
-	PYTHON=python
-fi
-if [ -n "$PYTHON" ] ; then
-	test_set_prereq PYTHON
+if [ -z "$TEST_INSTALLED_SCRIPTS" ] ; then
+	if [ -n "$PYTHON" ] && "$PYTHON" -c 'import mercurial' 2> /dev/null ; then
+		: Use chosen Python version
+	elif python3 -c 'import mercurial' 2> /dev/null ; then
+		PYTHON=python3
+	elif python2 -c 'import mercurial' 2> /dev/null ; then
+		PYTHON=python2
+	elif python -c 'import mercurial' 2> /dev/null ; then
+		PYTHON=python
+	fi
+	if [ -n "$PYTHON" ] ; then
+		test_set_prereq PYTHON
 
-	# Change shebang on a copy of scripts to chosen Python version
-	TEST_BIN="$SHARNESS_TRASH_DIRECTORY/bin"
-	mkdir -p "$TEST_BIN"
-	for s in git-remote-hg git-hg-helper ; do
-		printf "%s\n" "#!/usr/bin/env $PYTHON" > "$TEST_BIN/$s"
-		tail -n +2 "$SHARNESS_TEST_DIRECTORY/../$s" >> "$TEST_BIN/$s"
-		chmod u+x "$TEST_BIN/$s"
-	done
-	export PATH="$TEST_BIN${PATH:+:$PATH}"
-	unset TEST_BIN
+		# Change shebang on a copy of scripts to chosen Python version
+		TEST_BIN="$SHARNESS_TRASH_DIRECTORY/bin"
+		mkdir -p "$TEST_BIN"
+		for s in git-remote-hg git-hg-helper ; do
+			printf "%s\n" "#!/usr/bin/env $PYTHON" > "$TEST_BIN/$s"
+			tail -n +2 "$SHARNESS_TEST_DIRECTORY/../$s" >> "$TEST_BIN/$s"
+			chmod u+x "$TEST_BIN/$s"
+		done
+		export PATH="$TEST_BIN${PATH:+:$PATH}"
+		unset TEST_BIN
+	fi
+else
+	# The build/install process ensures Python is available
+	test_set_prereq PYTHON
 fi
 
 GIT_AUTHOR_EMAIL=author@example.com


### PR DESCRIPTION
This is useful for distros like Debian that do tests on installed packages.

See-also: https://ci.debian.net/
