### PR TITLE
Fixes bug where compat.getenv fails on Windows due to bytes type

### DIFF
--- a/git-remote-hg
+++ b/git-remote-hg
@@ -86,7 +86,7 @@ if sys.version_info[0] == 3:
         stdout = sys.stdout.buffer
         stderr = sys.stderr.buffer
         getcwd = os.getcwdb
-        getenv = os.getenvb if os.supports_bytes_environ else os.getenv
+        getenv = os.getenvb if os.supports_bytes_environ else lambda val, default: os.getenv(val.decode(), default.decode() if hasattr(default, 'decode') else default)
         urlparse = urllib.parse.urlparse
         urljoin = urllib.parse.urljoin
 else:
@@ -1849,6 +1849,7 @@ def main(args):
     marks = None
     is_tmp = False
     gitdir = compat.getenv(b'GIT_DIR', None)
+    gitdir = gitdir.encode() if hasattr(gitdir, 'encode') else gitdir # If the result is a string, get bytes instead.
 
     if len(args) < 3:
         die('Not enough arguments.')


### PR DESCRIPTION
On Windows with Python 3.10, the script fails due to getenv expecting a string and being passed bytes; likewise, the getenv call returns a string, while later functions expect bytes. This corrects the type passed in to a string on platforms that require it and corrects the returned value to be bytes, as required by later functions.